### PR TITLE
fix: remove is_paragraph

### DIFF
--- a/schema/paths/forms/eachForm.yml
+++ b/schema/paths/forms/eachForm.yml
@@ -30,7 +30,6 @@ get:
                       question:
                         id: 0
                         text_question:
-                          is_paragraph: false
                   - id: 2
                     title: 質問2
                     description: 質問2の説明文です。
@@ -38,7 +37,6 @@ get:
                       question:
                         id: 1
                         text_question:
-                          is_paragraph: true
                   - id: 3
                     title: 質問3
                     description: 質問3の説明文です。

--- a/schema/paths/forms/eachForm.yml
+++ b/schema/paths/forms/eachForm.yml
@@ -30,6 +30,7 @@ get:
                       question:
                         id: 0
                         text_question:
+                          validations: []
                   - id: 2
                     title: 質問2
                     description: 質問2の説明文です。
@@ -37,6 +38,7 @@ get:
                       question:
                         id: 1
                         text_question:
+                          validations: []
                   - id: 3
                     title: 質問3
                     description: 質問3の説明文です。

--- a/schema/paths/forms/types/questions.yml
+++ b/schema/paths/forms/types/questions.yml
@@ -46,6 +46,6 @@ components:
           description: 入力の検証ルール群
           type: array
           uniqueItems: true
-          minItems: 1
+          minItems: 0
           items:
             $ref: './validation.yml#/components/schemas/validation'

--- a/schema/paths/forms/types/questions.yml
+++ b/schema/paths/forms/types/questions.yml
@@ -42,10 +42,6 @@ components:
       description: テキストを入力させる質問
       type: object
       properties:
-        is_paragraph:
-          description: 段落を含むテキストかどうか
-          type: boolean
-          example: false
         validations:
           description: 入力の検証ルール群
           type: array
@@ -53,5 +49,3 @@ components:
           minItems: 1
           items:
             $ref: './validation.yml#/components/schemas/validation'
-      required:
-        - is_paragraph


### PR DESCRIPTION
- is_paragraphをtext_questionから削除した
- text_questionを含むexampleが何も定義を含んでいない部分が発生しエラーになるので、validationsが空というコードを含めるようにした