### PR TITLE
descriptionとresponse_periodをnullableにする

### DIFF
--- a/schema/types/forms/components.yml
+++ b/schema/types/forms/components.yml
@@ -13,10 +13,14 @@ components:
     form_description:
       description: フォームの説明
       type: string
+      nullable: true
       example: このフォームはお問い合わせをする際にご回答いただくフォームです。
     response_period:
-      description: 回答可能期間
+      description: |
+        回答可能期間
+        期間を指定しないとnullになります。
       type: object
+      nullable: true
       properties:
         start_at:
           description: 回答の受付を開始する日時

--- a/schema/types/forms/components.yml
+++ b/schema/types/forms/components.yml
@@ -16,9 +16,7 @@ components:
       nullable: true
       example: このフォームはお問い合わせをする際にご回答いただくフォームです。
     response_period:
-      description: |
-        回答可能期間
-        期間を指定しないとnullになります。
+      description: 回答可能期間
       type: object
       nullable: true
       properties:


### PR DESCRIPTION
どちらも設定されない可能性があるため。

@Lucky3028 
「受付開始日時を指定して、受付を終了する日時は指定しない」というようなことをは想定していないですが、そういったことはできたほうが良いですか？
できたほうが良いのであれば、教えてほしいです。

#76 を先にマージしてください。