### PR TITLE
fix: フォームに対して回答するAPISchema定義を見直す

### DIFF
--- a/schema/types/forms/components.yml
+++ b/schema/types/forms/components.yml
@@ -112,14 +112,9 @@ components:
       properties:
         question_id:
           $ref: "#/components/schemas/question_id"
-        uuid:
-          $ref: "../users/components.yml#/components/schemas/uuid"
         answer:
           type: string
           example: 整地鯖にアクセスできません。どうしたらいいですか。
-        timestamp:
-          type: string
-          format: date-time
     kind_of_labels:
       description: |
         ラベルの種類

--- a/schema/types/forms/definitions.yml
+++ b/schema/types/forms/definitions.yml
@@ -35,11 +35,18 @@ definitions:
       - id
   answers:
     description: 回答の配列
-    type: array
-    uniqueItems: true
-    minItems: 0
-    items:
-      $ref: "./components.yml#/components/schemas/answer"
+    properties:
+      uuid:
+        $ref: "../users/components.yml#/components/schemas/uuid"
+      timestamp:
+        type: string
+        format: date-time
+      answers:
+        type: array
+        uniqueItems: true
+        minItems: 0
+        items:
+          $ref: "./components.yml#/components/schemas/answer"
   kind_of_labels:
     type: object
     properties:


### PR DESCRIPTION
それぞれの回答に対して`uuid`と`timestamp`をもたせる必要はないので、回答に対して`uuid`と`timestamp`をもたせる