### PR TITLE
chore: Redoclyのコンテナが動かない不具合を修正

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,8 +11,8 @@ services:
     restart: always
   redocly:
     build:
-      context: ./docker
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ./docker/Dockerfile
     container_name: redocly
     ports:
       - 127.0.0.1:8082:8080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,12 @@ ENV PORT=8080
 
 EXPOSE 8080
 
-RUN npm install -g @redocly/cli
+RUN npm install -g @redocly/cli kill-port http-server
 
-ENTRYPOINT ["sh", "-c", "redocly preview-docs $SPEC_URL --port $PORT --host 0.0.0.0 --force"]
+USER node
+WORKDIR /tmp/files
+
+COPY --chmod=554 --chown=node:node ./docker/entrypoint.sh .
+COPY --chown=node:node ./.github/template.hbs .
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV PORT=8080
 
 EXPOSE 8080
 
-RUN npm install -g @redocly/cli kill-port http-server
+RUN npm install -g @redocly/cli http-server
 
 USER node
 WORKDIR /tmp/files

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+redocly build-docs /schema/openapi.yml -o ./docs/index.html -t ./template.hbs
+http-server ./docs -p $PORT


### PR DESCRIPTION
- そんなことはないのに、8080ポートが使用されているというエラーでコンテナが停止していた
- ポートを変えてもパソコンを再起動した直後でも同様の事象が発生した
- CIでやっているように、ドキュメントを生成して直接ファイルを自分でサーブする形にした