### PR TITLE
docs: forbiddenをレスポンスとして返すのを記載

### DIFF
--- a/schema/paths/forms/[formId]/answers/index.yml
+++ b/schema/paths/forms/[formId]/answers/index.yml
@@ -14,6 +14,8 @@ get:
       $ref: "../../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":

--- a/schema/paths/forms/[formId]/index.yml
+++ b/schema/paths/forms/[formId]/index.yml
@@ -35,6 +35,8 @@ delete:
       $ref: "../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":
@@ -62,6 +64,8 @@ patch:
       $ref: "../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":

--- a/schema/paths/forms/answers/comment/index.yml
+++ b/schema/paths/forms/answers/comment/index.yml
@@ -37,6 +37,8 @@ delete:
       $ref: "../../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":
@@ -59,6 +61,8 @@ patch:
       $ref: "../../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":

--- a/schema/paths/forms/answers/index.yml
+++ b/schema/paths/forms/answers/index.yml
@@ -12,6 +12,8 @@ get:
       $ref: "../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":

--- a/schema/paths/forms/labels/index.yml
+++ b/schema/paths/forms/labels/index.yml
@@ -34,6 +34,8 @@ post:
       description: "ラベルの作成に成功"
     "400":
       $ref: "../../../errors/errorResponses.yml#/components/responses/syntaxError"
+    "403":
+      $ref: "../../../errors/errorResponses.yml#/components/responses/forbidden"
     "401":
       $ref: "../../../errors/errorResponses.yml#/components/responses/unauthorized"
     "500":
@@ -57,6 +59,8 @@ delete:
       $ref: "../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":

--- a/schema/paths/forms/questions/index.yml
+++ b/schema/paths/forms/questions/index.yml
@@ -44,6 +44,8 @@ delete:
       $ref: "../../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":
       $ref: "../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "403":
+      $ref: "../../../errors/errorResponses.yml#/components/responses/forbidden"
     "404":
       $ref: "../../../errors/errorResponses.yml#/components/responses/notFound"
     "500":


### PR DESCRIPTION
一般ユーザーにアクセスされちゃまずいAPIにforbiddenが返される可能性があることを記載しました。

余談: フォームの一覧とか詳細取得とかに明らかに取得できちゃいけないデータ(例えばwebhookのURL)があるのでそこらへんをどうするかをもう一度考えたほうが良さそう