### PR TITLE
fix: /formのGETで返す情報を、フォーム全体ではなく最低限の情報のみ返すように修正

### DIFF
--- a/schema/paths/forms/index.yml
+++ b/schema/paths/forms/index.yml
@@ -77,7 +77,7 @@ get:
             uniqueItems: true
             minItems: 1
             items:
-              $ref: "../../types/forms/definitions.yml#/definitions/form"
+              $ref: "../../types/forms/definitions.yml#/definitions/simple_form"
     "400":
       $ref: "../../errors/errorResponses.yml#/components/responses/syntaxError"
     "401":

--- a/schema/types/forms/definitions.yml
+++ b/schema/types/forms/definitions.yml
@@ -26,6 +26,20 @@ definitions:
     required:
       - id
       - title
+  simple_form:
+    description: フォームの最低限必要な情報のみを集めたもの。
+    type: object
+    properties:
+      id:
+        readOnly: true
+        allOf:
+          - $ref: "./components.yml#/components/schemas/id"
+      title:
+        $ref: "./components.yml#/components/schemas/title"
+      description:
+        $ref: "./components.yml#/components/schemas/description"
+      response_period:
+        $ref: "./components.yml#/components/schemas/response_period"
   questions:
     description: 質問の配列
     type: object


### PR DESCRIPTION
タイトルの通りで、`/forms`で`webhook_url`などが取得されるとまずいので最低限の情報のみ返すように修正