### PR TITLE
フォームの質問を取得するエンドポイントの定義

### DIFF
--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -27,13 +27,15 @@ paths:
     $ref: "./paths/forms/index.yml"
   /forms/{formId}:
     $ref: "./paths/forms/[formId]/index.yml"
+  /forms/{formId}/questions:
+    $ref: "./paths/forms/[formId]/questions/index.yml"
+  /forms/{formId}/answers:
+    $ref: "./paths/forms/[formId]/answers/index.yml"
   /forms/questions:
     $ref: "./paths/forms/questions/index.yml"
   /forms/answers:
     $ref: "./paths/forms/answers/index.yml"
   /forms/answers/comment:
     $ref: "./paths/forms/answers/comment/index.yml"
-  /forms/{formId}/answers:
-    $ref: "./paths/forms/[formId]/answers/index.yml"
   /forms/labels:
     $ref: "./paths/forms/labels/index.yml"

--- a/schema/paths/forms/[formId]/questions/index.yml
+++ b/schema/paths/forms/[formId]/questions/index.yml
@@ -1,0 +1,21 @@
+get:
+  operationId: getQuestions
+  summary: 質問の取得
+  description: 指定したフォームの質問をすべて取得します。
+  parameters:
+    - $ref: "../../../../types/forms/parameters.yml#/parameters/id"
+  responses:
+    "200":
+      description: 指定されたフォームの回答の取得に成功
+      content:
+        application/json:
+          schema:
+            $ref: "../../../../types/forms/definitions.yml#/definitions/questions"
+    "400":
+      $ref: "../../../../errors/errorResponses.yml#/components/responses/syntaxError"
+    "401":
+      $ref: "../../../../errors/errorResponses.yml#/components/responses/unauthorized"
+    "404":
+      $ref: "../../../../errors/errorResponses.yml#/components/responses/notFound"
+    "500":
+      $ref: "../../../../errors/errorResponses.yml#/components/responses/internalServerError"

--- a/schema/types/forms/components.yml
+++ b/schema/types/forms/components.yml
@@ -95,6 +95,16 @@ components:
         - MULTIPLE
         - SINGLE
       example: TEXT
+    question_choices:
+      description: |
+        質問の選択肢の配列。
+        TEXT以外の場合は指定必須。
+      type: array
+      uniqueItems: true
+      minItems: 1
+      items:
+        type: string
+      example: []
     is_required:
       description: |
         質問に対する解答を必須にする。
@@ -115,6 +125,8 @@ components:
           $ref: "#/components/schemas/question_description"
         question_type:
           $ref: "#/components/schemas/question_type"
+        choices:
+          $ref: "#/components/schemas/question_choices"
         is_required:
           $ref: "#/components/schemas/is_required"
     questions:

--- a/schema/types/forms/definitions.yml
+++ b/schema/types/forms/definitions.yml
@@ -45,7 +45,9 @@ definitions:
     type: object
     properties:
       form_id:
-        $ref: "./components.yml#/components/schemas/id"
+        writeOnly: true
+        allOf:
+          - $ref: "./components.yml#/components/schemas/id"
       questions:
         $ref: "./components.yml#/components/schemas/questions"
   question_id:


### PR DESCRIPTION
#116 を先にマージしてください。

一般ユーザーがフォームの質問を取得する手段がなくなっているため、それを回避するためにフォームの質問を取得できるエンドポイントを定義しました。

また、`question`の定義に`choices`が書かれていなかったのでその内容を記載しています。