### PR TITLE
docs: batch_answersの定義からuuidとtimestampの定義を削除

### DIFF
--- a/schema/types/forms/definitions.yml
+++ b/schema/types/forms/definitions.yml
@@ -67,11 +67,6 @@ definitions:
     description: ひとまとまりの回答
     type: object
     properties:
-      uuid:
-        $ref: "../users/components.yml#/components/schemas/uuid"
-      timestamp:
-        type: string
-        format: date-time
       title:
         type: string
         description: titleをnullにするとデフォルト設定が適用


### PR DESCRIPTION
close #121 
close #122 

UUIDは認証情報から、timestampはバックエンド側で生成するように変更する