### PR TITLE
ローカルでDcokerコンテナを立ち上げたときにredocly側がエラーで動かなかったのを修正する

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV PORT=8080
 
 EXPOSE 8080
 
-RUN npm install -g @typespec/compiler @redocly/cli http-server 
+RUN npm install -g @redocly/cli http-server 
 
 USER node
 WORKDIR /tmp/files

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-tsp compile ./src
-
-redocly build-docs ./tsp-output/@typespec/openapi3/openapi.yaml -o ./docs/index.html -t ./template.hbs
+redocly build-docs /schema/openapi.yaml -o ./docs/index.html -t ./template.hbs
 http-server ./docs -p $PORT


### PR DESCRIPTION
- コンテナ起動時にtspのコンパイルとredoclyのドキュメント生成がこけていた
- tspのコンパイルは`compile-and-up-compose.sh`でしていて、Dockerコンテナはコンパイルして生成された`openapi,yaml`をボリュームでマウントしているので、Dockerコンテナの中でtspのコンパイルはしなくてよい
- それに伴って、redocly CLIがマウントされたyamlをみにいくように修正