### PR TITLE
chore: change docker base image to `22-slim`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim
+FROM node:22-slim
 
 ENV PAGE_TITLE=ReDoc
 ENV SPEC_URL=https://petstore3.swagger.io/api/v3/openapi.json


### PR DESCRIPTION
Debian 11に固定する意味はないかなと思ったので、`bullseye`の指定を外しました。
RenovateはDebianのバージョンを英語で指定している場合のバージョンアップに対応してなさそうですし。